### PR TITLE
닉네임 이용가능성 조회 시 응답 결과가 예상과 반대로 나오는 문제 수정

### DIFF
--- a/user/src/main/kotlin/com/damaba/user/application/user/CheckNicknameAvailabilityUseCase.kt
+++ b/user/src/main/kotlin/com/damaba/user/application/user/CheckNicknameAvailabilityUseCase.kt
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Service
 @Service
 class CheckNicknameAvailabilityUseCase(private val userService: UserService) {
     operator fun invoke(nickname: String): Boolean =
-        userService.doesNicknameExist(nickname)
+        !userService.doesNicknameExist(nickname)
 }

--- a/user/src/test/kotlin/com/damaba/user/application/user/CheckNicknameAvailabilityUseCaseTest.kt
+++ b/user/src/test/kotlin/com/damaba/user/application/user/CheckNicknameAvailabilityUseCaseTest.kt
@@ -1,30 +1,30 @@
 package com.damaba.user.application.user
 
 import com.damaba.user.domain.user.UserService
-import com.damaba.user.util.RandomTestUtils.Companion.randomBoolean
 import com.damaba.user.util.RandomTestUtils.Companion.randomString
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import kotlin.test.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class CheckNicknameAvailabilityUseCaseTest {
     private val userService: UserService = mockk()
     private val sut: CheckNicknameAvailabilityUseCase = CheckNicknameAvailabilityUseCase(userService)
 
-    @Test
-    fun `닉네임이 주어지고, 주어진 닉네임의 이용가능성을 확인한다`() {
+    @ValueSource(booleans = [true, false])
+    @ParameterizedTest
+    fun `닉네임이 주어지고, 주어진 닉네임의 이용가능성을 확인한다`(doesNicknameExist: Boolean) {
         // given
         val nickname = randomString()
-        val expectedResult = randomBoolean()
-        every { userService.doesNicknameExist(nickname) } returns expectedResult
+        every { userService.doesNicknameExist(nickname) } returns doesNicknameExist
 
         // when
-        val actualResult = sut.invoke(nickname)
+        val result = sut.invoke(nickname)
 
         // then
         verify { userService.doesNicknameExist(nickname) }
-        assertThat(actualResult).isEqualTo(expectedResult)
+        assertThat(result).isEqualTo(!doesNicknameExist)
     }
 }


### PR DESCRIPTION
Closed #7

- 닉네임 이용가능성 조회 시 응답 결과가 예상과 반대로 나오는 문제 수정