### PR TITLE
[유저 정보 수정 API] transaction 실패 시 업로드된 이미지 파일을 삭제하는 복구 로직 추가

### DIFF
--- a/damaba/src/main/kotlin/com/damaba/damaba/DamabaApplication.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/DamabaApplication.kt
@@ -2,6 +2,7 @@ package com.damaba.damaba
 
 import com.damaba.user.property.AwsProperties
 import com.damaba.user.property.DamabaProperties
+import com.damaba.user.property.ThreadPoolProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -19,7 +20,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
     ],
 )
 @PropertySource("classpath:env.properties")
-@EnableConfigurationProperties(DamabaProperties::class, AwsProperties::class)
+@EnableConfigurationProperties(DamabaProperties::class, ThreadPoolProperties::class, AwsProperties::class)
 @EntityScan(basePackages = ["com.damaba.user"])
 @EnableJpaRepositories(basePackages = ["com.damaba.user"])
 @EnableFeignClients(basePackages = ["com.damaba.user"])

--- a/damaba/src/main/kotlin/com/damaba/damaba/config/AsyncConfig.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/config/AsyncConfig.kt
@@ -1,0 +1,24 @@
+package com.damaba.damaba.config
+
+import com.damaba.common_logging.MdcThreadPoolTaskDecorator
+import com.damaba.damaba.property.ThreadPoolProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean
+    fun threadPoolTaskExecutor(threadPoolProperties: ThreadPoolProperties): ThreadPoolTaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = threadPoolProperties.corePoolSize
+        executor.maxPoolSize = threadPoolProperties.maxPoolSize
+        executor.queueCapacity = threadPoolProperties.queueCapacity
+        executor.setTaskDecorator(MdcThreadPoolTaskDecorator())
+        executor.setThreadNamePrefix("damaba-async-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/damaba/src/main/kotlin/com/damaba/damaba/config/LogTraceAspect.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/config/LogTraceAspect.kt
@@ -12,18 +12,19 @@ import org.springframework.stereotype.Component
 @Aspect
 class LogTraceAspect(private val logTrace: LogTrace) {
     @Around(
-        value = "com.damaba.damaba.config.Pointcuts.controllerPoint() || " +
-            "com.damaba.damaba.config.Pointcuts.servicePoint() || " +
-            "com.damaba.damaba.config.Pointcuts.repositoryPoint()",
+        value = "com.damaba.damaba.config.Pointcuts.controllerPointcuts() || " +
+            "com.damaba.damaba.config.Pointcuts.useCasePointcuts() || " +
+            "com.damaba.damaba.config.Pointcuts.domainServicePointcuts() || " +
+            "com.damaba.damaba.config.Pointcuts.repositoryPointcuts() || " +
+            "com.damaba.damaba.config.Pointcuts.infrastructureServicePointcuts() || " +
+            "com.damaba.damaba.config.Pointcuts.eventListenerPointcuts()",
     )
     fun execute(joinPoint: ProceedingJoinPoint): Any? {
         var status: TraceStatus? = null
         try {
             val message = joinPoint.signature.toShortString()
             status = logTrace.begin(message)
-
             val result: Any? = joinPoint.proceed()
-
             logTrace.end(status)
             return result
         } catch (ex: Exception) {
@@ -36,15 +37,27 @@ class LogTraceAspect(private val logTrace: LogTrace) {
 }
 
 class Pointcuts {
-    @Pointcut("@within(org.springframework.stereotype.Controller) || @within(org.springframework.web.bind.annotation.RestController)")
-    fun controllerPoint() {
+    @Pointcut("execution(* com.damaba..controller..*Controller.*(..))")
+    fun controllerPointcuts() {
     }
 
-    @Pointcut("@within(org.springframework.stereotype.Service)")
-    fun servicePoint() {
+    @Pointcut("execution(* com.damaba..application..*UseCase.*(..))")
+    fun useCasePointcuts() {
     }
 
-    @Pointcut("@within(org.springframework.stereotype.Repository)")
-    fun repositoryPoint() {
+    @Pointcut("execution(* com.damaba..domain..*Service.*(..))")
+    fun domainServicePointcuts() {
+    }
+
+    @Pointcut("execution(* com.damaba..infrastructure..*Repository.*(..))")
+    fun repositoryPointcuts() {
+    }
+
+    @Pointcut("execution(* com.damaba..infrastructure..*Service.*(..))")
+    fun infrastructureServicePointcuts() {
+    }
+
+    @Pointcut("execution(* com.damaba..infrastructure..*EventListener.*(..))")
+    fun eventListenerPointcuts() {
     }
 }

--- a/damaba/src/main/kotlin/com/damaba/damaba/property/ThreadPoolProperties.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/property/ThreadPoolProperties.kt
@@ -1,0 +1,10 @@
+package com.damaba.damaba.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "thread-pool")
+data class ThreadPoolProperties(
+    val corePoolSize: Int,
+    val maxPoolSize: Int,
+    val queueCapacity: Int,
+)

--- a/damaba/src/main/resources/application.yml
+++ b/damaba/src/main/resources/application.yml
@@ -7,6 +7,11 @@ damaba:
     access-token-duration-millis: 7200000  # 2 day
     refresh-token-duration-millis: 2592000 # 1 month
 
+thread-pool:
+  core-pool-size: ${THREAD_POOL_CORE_POOL_SIZE}
+  max-pool-size: ${THREAD_POOL_MAX_POOL_SIZE}
+  queue-capacity: ${THREAD_POOL_QUEUE_CAPACITY}
+
 spring:
   application:
     name: damaba-damaba

--- a/user/build.gradle.kts
+++ b/user/build.gradle.kts
@@ -121,6 +121,7 @@ tasks.jacocoTestReport {
                         "**/domain/**/*",
                         "**/infrastructure/**/*Repository*",
                         "**/infrastructure/**/*Service*",
+                        "**/infrastructure/**/*EventListener*",
                     ),
                 )
             },
@@ -153,6 +154,7 @@ tasks.jacocoTestCoverageVerification {
                 "*.domain.*.*",
                 "*.infrastructure.*.*Repository*",
                 "*.infrastructure.*.*Service*",
+                "*.infrastructure.*.*EventListener*",
             )
         }
     }

--- a/user/src/main/kotlin/com/damaba/user/domain/file/FileStorageRepository.kt
+++ b/user/src/main/kotlin/com/damaba/user/domain/file/FileStorageRepository.kt
@@ -9,4 +9,11 @@ interface FileStorageRepository {
      * @return 업로드된 파일 정보
      */
     fun upload(file: UploadFile, path: String): UploadedFile
+
+    /**
+     * 업로드 된 파일을 삭제합니다.
+     *
+     * @param file 삭제할 파일 정보
+     */
+    fun delete(file: UploadedFile)
 }

--- a/user/src/main/kotlin/com/damaba/user/domain/file/FileUploadRollbackEvent.kt
+++ b/user/src/main/kotlin/com/damaba/user/domain/file/FileUploadRollbackEvent.kt
@@ -1,0 +1,3 @@
+package com.damaba.user.domain.file
+
+data class FileUploadRollbackEvent(val uploadedFiles: List<UploadedFile>)

--- a/user/src/main/kotlin/com/damaba/user/infrastructure/file/AwsS3FileStorageRepository.kt
+++ b/user/src/main/kotlin/com/damaba/user/infrastructure/file/AwsS3FileStorageRepository.kt
@@ -8,6 +8,7 @@ import com.damaba.user.property.DamabaProperties
 import org.springframework.stereotype.Repository
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.util.UUID
 
@@ -32,6 +33,15 @@ class AwsS3FileStorageRepository(
         return UploadedFile(
             name = storedFileName,
             url = "${damabaProperties.fileServerUrl}/$storedFileName",
+        )
+    }
+
+    override fun delete(file: UploadedFile) {
+        s3Client.deleteObject(
+            DeleteObjectRequest.builder()
+                .bucket(awsProperties.s3.bucketName)
+                .key(file.name)
+                .build(),
         )
     }
 

--- a/user/src/main/kotlin/com/damaba/user/infrastructure/file/FileUploadRollbackEventListener.kt
+++ b/user/src/main/kotlin/com/damaba/user/infrastructure/file/FileUploadRollbackEventListener.kt
@@ -1,0 +1,19 @@
+package com.damaba.user.infrastructure.file
+
+import com.damaba.user.domain.file.FileStorageRepository
+import com.damaba.user.domain.file.FileUploadRollbackEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class FileUploadRollbackEventListener(private val fileStorageRepository: FileStorageRepository) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    fun handle(event: FileUploadRollbackEvent) {
+        event.uploadedFiles.forEach { uploadedFile ->
+            fileStorageRepository.delete(uploadedFile)
+        }
+    }
+}

--- a/user/src/test/kotlin/com/damaba/user/infrastructure/file/AwsS3FileStorageRepositoryTest.kt
+++ b/user/src/test/kotlin/com/damaba/user/infrastructure/file/AwsS3FileStorageRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.damaba.user.infrastructure.file
 
+import com.damaba.user.domain.file.UploadedFile
 import com.damaba.user.property.AwsProperties
 import com.damaba.user.property.DamabaProperties
 import com.damaba.user.util.RandomTestUtils.Companion.randomString
@@ -15,9 +16,12 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectResponse
 import java.util.stream.Stream
+import kotlin.test.Test
 
 class AwsS3FileStorageRepositoryTest {
     companion object {
@@ -59,6 +63,22 @@ class AwsS3FileStorageRepositoryTest {
         confirmVerifiedEveryMocks()
         assertThat(result.name).isNotBlank()
         assertThat(result.url).isNotBlank()
+    }
+
+    @Test
+    fun `삭제할 파일 정보가 주어지고, 파일을 삭제한다`() {
+        // given
+        val fileForDelete = UploadedFile(name = randomString(), url = randomString())
+        every {
+            s3Client.deleteObject(any(DeleteObjectRequest::class))
+        } returns DeleteObjectResponse.builder().build()
+
+        // when
+        sut.delete(fileForDelete)
+
+        // then
+        verify { s3Client.deleteObject(any(DeleteObjectRequest::class)) }
+        confirmVerifiedEveryMocks()
     }
 
     private fun confirmVerifiedEveryMocks() {

--- a/user/src/test/kotlin/com/damaba/user/infrastructure/file/FileUploadRollbackEventListenerTest.kt
+++ b/user/src/test/kotlin/com/damaba/user/infrastructure/file/FileUploadRollbackEventListenerTest.kt
@@ -1,0 +1,35 @@
+package com.damaba.user.infrastructure.file
+
+import com.damaba.user.domain.file.FileStorageRepository
+import com.damaba.user.domain.file.FileUploadRollbackEvent
+import com.damaba.user.domain.file.UploadedFile
+import com.damaba.user.util.RandomTestUtils.Companion.randomString
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class FileUploadRollbackEventListenerTest {
+    private val fileStorageRepository: FileStorageRepository = mockk()
+    private val sut: FileUploadRollbackEventListener = FileUploadRollbackEventListener(fileStorageRepository)
+
+    @Test
+    fun `FileUploadRollbackEvent가 발생하면, 업로드되었던 파일들을 삭제한다`() {
+        // given
+        val uploadedFiles = listOf(
+            UploadedFile(randomString(), randomString()),
+            UploadedFile(randomString(), randomString()),
+        )
+        val event = FileUploadRollbackEvent(uploadedFiles)
+        every { fileStorageRepository.delete(any(UploadedFile::class)) } just Runs
+
+        // when
+        sut.handle(event)
+
+        // then
+        verify(exactly = 1) { fileStorageRepository.delete(uploadedFiles[0]) }
+        verify(exactly = 1) { fileStorageRepository.delete(uploadedFiles[1]) }
+    }
+}


### PR DESCRIPTION
Closed #24

- 유저 수정에 실패한 경우에 대한, 업로드된 이미지 파일을 삭제하는 복구 로직 추가
- Thread pool 설정 추가