### PR TITLE
프로모션 유형에서 `MODEL` 제거

### DIFF
--- a/damaba/src/main/kotlin/com/damaba/damaba/adapter/inbound/promotion/dto/PostPromotionRequest.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/adapter/inbound/promotion/dto/PostPromotionRequest.kt
@@ -15,8 +15,8 @@ data class PostPromotionRequest(
     @Schema(description = "프로모션 종류")
     val type: PromotionType,
 
-    @Schema(description = "(프로모션 종류가 이벤트인 경우에만 해당) 이벤트 종류")
-    val eventType: EventType?,
+    @Schema(description = "이벤트 종류")
+    val eventType: EventType,
 
     @Schema(description = "제목. 제목은 3~20 글자여야 합니다.", example = "이벤트 이름")
     val title: String,

--- a/damaba/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJpaEntity.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJpaEntity.kt
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 class PromotionJpaEntity(
     authorId: Long?,
     type: PromotionType,
-    eventType: EventType?,
+    eventType: EventType,
     title: String,
     content: String,
     address: AddressJpaEntity,
@@ -49,8 +49,8 @@ class PromotionJpaEntity(
         private set
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "event_type")
-    var eventType: EventType? = eventType
+    @Column(name = "event_type", nullable = false)
+    var eventType: EventType = eventType
         private set
 
     @Column(name = "title", nullable = false)

--- a/damaba/src/main/kotlin/com/damaba/damaba/application/port/inbound/promotion/PostPromotionUseCase.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/application/port/inbound/promotion/PostPromotionUseCase.kt
@@ -23,7 +23,7 @@ interface PostPromotionUseCase {
     data class Command(
         val authorId: Long,
         val type: PromotionType,
-        val eventType: EventType?,
+        val eventType: EventType,
         val title: String,
         val content: String,
         val address: Address,
@@ -40,9 +40,6 @@ interface PostPromotionUseCase {
             AddressValidator.validate(address)
             PromotionValidator.validateTitle(title)
             PromotionValidator.validateContent(content)
-            if (type == PromotionType.EVENT && eventType == null) {
-                throw ValidationException("이벤트 종류를 선택해야 합니다.")
-            }
             if (images.isEmpty() || images.size > 10) {
                 throw ValidationException("프로모션의 이미지는 최소 1장부터 최대 10장까지 첨부할 수 있습니다.")
             }

--- a/damaba/src/main/kotlin/com/damaba/damaba/application/service/promotion/PromotionService.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/application/service/promotion/PromotionService.kt
@@ -13,7 +13,6 @@ import com.damaba.damaba.domain.common.Pagination
 import com.damaba.damaba.domain.promotion.Promotion
 import com.damaba.damaba.domain.promotion.PromotionActiveRegion
 import com.damaba.damaba.domain.promotion.PromotionImage
-import com.damaba.damaba.domain.promotion.constant.PromotionType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -55,7 +54,7 @@ class PromotionService(
     ): Promotion = Promotion.create(
         authorId = command.authorId,
         type = command.type,
-        eventType = if (command.type == PromotionType.EVENT) command.eventType else null,
+        eventType = command.eventType,
         title = command.title,
         content = command.content,
         address = command.address,

--- a/damaba/src/main/kotlin/com/damaba/damaba/domain/promotion/Promotion.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/domain/promotion/Promotion.kt
@@ -9,7 +9,7 @@ class Promotion(
     val id: Long,
     val authorId: Long?,
     val type: PromotionType,
-    val eventType: EventType?,
+    val eventType: EventType,
     val title: String,
     val content: String,
     val address: Address,
@@ -34,7 +34,7 @@ class Promotion(
         fun create(
             authorId: Long,
             type: PromotionType,
-            eventType: EventType?,
+            eventType: EventType,
             title: String,
             content: String,
             address: Address,

--- a/damaba/src/main/kotlin/com/damaba/damaba/domain/promotion/constant/PromotionType.kt
+++ b/damaba/src/main/kotlin/com/damaba/damaba/domain/promotion/constant/PromotionType.kt
@@ -2,5 +2,4 @@ package com.damaba.damaba.domain.promotion.constant
 
 enum class PromotionType {
     EVENT,
-    MODEL,
 }

--- a/damaba/src/main/resources/schema.sql
+++ b/damaba/src/main/resources/schema.sql
@@ -42,7 +42,7 @@ CREATE TABLE promotion
     id                        BIGINT       NOT NULL AUTO_INCREMENT,
     author_id                 BIGINT COMMENT '(FK) id of user(author)',
     type                      VARCHAR(255) NOT NULL,
-    event_type                VARCHAR(255),
+    event_type                VARCHAR(255) NOT NULL,
     title                     VARCHAR(20)  NOT NULL,
     content                   VARCHAR(500) NOT NULL,
     sido                      VARCHAR(255) NOT NULL,

--- a/damaba/src/test/kotlin/com/damaba/damaba/application/port/inbound/promotion/PostPromotionUseCaseCommandTest.kt
+++ b/damaba/src/test/kotlin/com/damaba/damaba/application/port/inbound/promotion/PostPromotionUseCaseCommandTest.kt
@@ -39,12 +39,6 @@ class PostPromotionUseCaseCommandTest {
         assertThat(exception).isInstanceOf(ValidationException::class.java)
     }
 
-    @Test
-    fun `프로모션 유형이 이벤트이나 이벤트 유형이 없으면 ValidationException이 발생한다`() {
-        val exception = catchThrowable { createCommand(promotionType = PromotionType.EVENT, eventType = null) }
-        assertThat(exception).isInstanceOf(ValidationException::class.java)
-    }
-
     @ParameterizedTest
     @MethodSource("invalidImageSizeProvider")
     fun `이미지 개수가 유효하지 않으면 ValidationException이 발생한다`(images: List<UploadFile>) {
@@ -85,7 +79,7 @@ class PostPromotionUseCaseCommandTest {
             title: String = "Valid title",
             content: String = "Valid content",
             promotionType: PromotionType = PromotionType.EVENT,
-            eventType: EventType? = EventType.FREE,
+            eventType: EventType = EventType.FREE,
             images: List<UploadFile> = List(3) { createUploadFile() },
             activeRegions: Set<Region> = setOf(Region("서울", "강남구")),
         ) = PostPromotionUseCase.Command(

--- a/damaba/src/test/kotlin/com/damaba/damaba/application/service/promotion/PromotionServiceTest.kt
+++ b/damaba/src/test/kotlin/com/damaba/damaba/application/service/promotion/PromotionServiceTest.kt
@@ -100,32 +100,7 @@ class PromotionServiceTest {
     @Test
     fun `등록할 이벤트 프로모션 정보들이 주어지고, 주어진 정보로 이벤트 프로모션을 생성 및 등록한다`() {
         // given
-        val command = createPostPromotionCommand(PromotionType.EVENT, EventType.FREE)
-        val expectedResult = createPromotion()
-        every {
-            uploadFilesPort.upload(command.images, any(String::class))
-        } returns List(3) { createUploadedFile() }
-        every { savePromotionPort.save(any(Promotion::class)) } returns expectedResult
-
-        // when
-        val actualResult = sut.postPromotion(command)
-
-        // then
-        verifyOrder {
-            uploadFilesPort.upload(command.images, any(String::class))
-            savePromotionPort.save(any(Promotion::class))
-        }
-        confirmVerifiedEveryMocks()
-        assertThat(actualResult).isEqualTo(expectedResult)
-        assertThatIterable(actualResult.images).isEqualTo(expectedResult.images)
-        assertThatIterable(actualResult.activeRegions).isEqualTo(expectedResult.activeRegions)
-        assertThatIterable(actualResult.hashtags).isEqualTo(expectedResult.hashtags)
-    }
-
-    @Test
-    fun `등록할 모델 프로모션 정보들이 주어지고, 주어진 정보로 모델 프로모션을 생성 및 등록한다`() {
-        // given
-        val command = createPostPromotionCommand(PromotionType.MODEL, null)
+        val command = createPostPromotionCommand()
         val expectedResult = createPromotion()
         every {
             uploadFilesPort.upload(command.images, any(String::class))
@@ -150,7 +125,7 @@ class PromotionServiceTest {
     @Test
     fun `프로모션을 생성 및 등록한다, 이미지는 성공적으로 업로드 되었지만 프로모션 저장에 실패할 경우, 파일 롤백 이벤트를 발행하고 예외가 발생한다`() {
         // given
-        val command = createPostPromotionCommand(PromotionType.EVENT, EventType.FREE)
+        val command = createPostPromotionCommand()
         val expectedThrownException = IllegalStateException()
         every {
             uploadFilesPort.upload(command.images, any(String::class))
@@ -171,13 +146,10 @@ class PromotionServiceTest {
         assertThat(actualThrownException).isInstanceOf(expectedThrownException::class.java)
     }
 
-    private fun createPostPromotionCommand(
-        promotionType: PromotionType,
-        eventType: EventType?,
-    ) = PostPromotionUseCase.Command(
+    private fun createPostPromotionCommand() = PostPromotionUseCase.Command(
         authorId = randomLong(),
-        type = promotionType,
-        eventType = eventType,
+        type = PromotionType.EVENT,
+        eventType = EventType.FREE,
         title = randomString(len = 10),
         content = randomString(),
         address = createAddress(),

--- a/damaba/src/test/kotlin/com/damaba/damaba/util/TestFixture.kt
+++ b/damaba/src/test/kotlin/com/damaba/damaba/util/TestFixture.kt
@@ -69,8 +69,8 @@ object TestFixture {
     fun createPromotion(
         id: Long = randomLong(),
         authorId: Long? = randomLong(),
-        type: PromotionType = PromotionType.MODEL,
-        eventType: EventType? = null,
+        type: PromotionType = PromotionType.EVENT,
+        eventType: EventType = EventType.FREE,
         title: String = randomString(10),
         content: String = randomString(30),
         address: Address = createAddress(),


### PR DESCRIPTION
Closed #40 

- 프로모션 유형에서 `MODEL` 제거, 프로모션의 `evnetType`을 필수값으로 설정