### PR TITLE
[내 정보 수정 API] 성별을 수정 불가능하도록 API 변경

### DIFF
--- a/user/src/main/kotlin/com/damaba/user/adapter/inbound/user/dto/UpdateMyInfoRequest.kt
+++ b/user/src/main/kotlin/com/damaba/user/adapter/inbound/user/dto/UpdateMyInfoRequest.kt
@@ -2,15 +2,11 @@ package com.damaba.user.adapter.inbound.user.dto
 
 import com.damaba.user.application.port.inbound.user.UpdateMyInfoUseCase
 import com.damaba.user.domain.user.UserProfileImage
-import com.damaba.user.domain.user.constant.Gender
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class UpdateMyInfoRequest(
     @Schema(description = "닉네임", example = "치와와")
     val nickname: String,
-
-    @Schema(description = "성별")
-    val gender: Gender,
 
     @Schema(description = "인스타 아이디", example = "damaba.unofficial")
     val instagramId: String?,
@@ -21,7 +17,6 @@ data class UpdateMyInfoRequest(
     fun toCommand(requestUserId: Long): UpdateMyInfoUseCase.Command = UpdateMyInfoUseCase.Command(
         userId = requestUserId,
         nickname = this.nickname,
-        gender = this.gender,
         instagramId = this.instagramId,
         profileImage = profileImage,
     )

--- a/user/src/main/kotlin/com/damaba/user/application/port/inbound/user/UpdateMyInfoUseCase.kt
+++ b/user/src/main/kotlin/com/damaba/user/application/port/inbound/user/UpdateMyInfoUseCase.kt
@@ -3,7 +3,6 @@ package com.damaba.user.application.port.inbound.user
 import com.damaba.user.domain.user.User
 import com.damaba.user.domain.user.UserProfileImage
 import com.damaba.user.domain.user.UserValidator
-import com.damaba.user.domain.user.constant.Gender
 
 interface UpdateMyInfoUseCase {
     fun updateMyInfo(command: Command): User
@@ -11,7 +10,6 @@ interface UpdateMyInfoUseCase {
     data class Command(
         val userId: Long,
         val nickname: String,
-        val gender: Gender,
         val instagramId: String?,
         val profileImage: UserProfileImage,
     ) {

--- a/user/src/main/kotlin/com/damaba/user/application/service/user/UserService.kt
+++ b/user/src/main/kotlin/com/damaba/user/application/service/user/UserService.kt
@@ -46,7 +46,6 @@ class UserService(
 
         user.update(
             nickname = command.nickname,
-            gender = command.gender,
             instagramId = command.instagramId,
             profileImage = command.profileImage,
         )

--- a/user/src/main/kotlin/com/damaba/user/domain/user/User.kt
+++ b/user/src/main/kotlin/com/damaba/user/domain/user/User.kt
@@ -40,12 +40,10 @@ class User(
 
     fun update(
         nickname: String,
-        gender: Gender,
         instagramId: String?,
         profileImage: UserProfileImage,
     ) {
         this.nickname = nickname
-        this.gender = gender
         this.instagramId = instagramId
         this.profileImage = profileImage
     }

--- a/user/src/test/kotlin/com/damaba/user/adapter/inbound/user/UserControllerTest.kt
+++ b/user/src/test/kotlin/com/damaba/user/adapter/inbound/user/UserControllerTest.kt
@@ -6,7 +6,6 @@ import com.damaba.user.application.port.inbound.user.GetMyInfoUseCase
 import com.damaba.user.application.port.inbound.user.UpdateMyInfoUseCase
 import com.damaba.user.config.ControllerTestConfig
 import com.damaba.user.domain.user.UserProfileImage
-import com.damaba.user.domain.user.constant.Gender
 import com.damaba.user.util.RandomTestUtils.Companion.randomBoolean
 import com.damaba.user.util.RandomTestUtils.Companion.randomLong
 import com.damaba.user.util.RandomTestUtils.Companion.randomString
@@ -76,14 +75,12 @@ class UserControllerTest @Autowired constructor(
         val requestUser = createUser()
         val request = UpdateMyInfoRequest(
             nickname = randomString(len = 7),
-            gender = Gender.FEMALE,
             instagramId = randomString(),
             profileImage = UserProfileImage(randomString(), randomUrl()),
         )
         val expectedResult = createUser(
             id = requestUser.id,
             nickname = request.nickname,
-            gender = request.gender,
             instagramId = request.instagramId,
         )
         every { updateMyInfoUseCase.updateMyInfo(request.toCommand(requestUser.id)) } returns expectedResult

--- a/user/src/test/kotlin/com/damaba/user/application/port/inbound/user/UpdateMyInfoUseCaseCommandTest.kt
+++ b/user/src/test/kotlin/com/damaba/user/application/port/inbound/user/UpdateMyInfoUseCaseCommandTest.kt
@@ -2,7 +2,6 @@ package com.damaba.user.application.port.inbound.user
 
 import com.damaba.common_exception.ValidationException
 import com.damaba.user.domain.user.UserProfileImage
-import com.damaba.user.domain.user.constant.Gender
 import com.damaba.user.util.RandomTestUtils.Companion.randomString
 import com.damaba.user.util.RandomTestUtils.Companion.randomUrl
 import org.assertj.core.api.Assertions.assertThat
@@ -20,7 +19,6 @@ class UpdateMyInfoUseCaseCommandTest {
             UpdateMyInfoUseCase.Command(
                 userId = 1,
                 nickname = invalidNickname,
-                gender = Gender.MALE,
                 instagramId = randomString(),
                 profileImage = UserProfileImage(randomString(), randomUrl()),
             )
@@ -40,7 +38,6 @@ class UpdateMyInfoUseCaseCommandTest {
             UpdateMyInfoUseCase.Command(
                 userId = 1,
                 nickname = randomString(len = 5),
-                gender = Gender.MALE,
                 instagramId = invalidInstagramId,
                 profileImage = UserProfileImage(randomString(), randomUrl()),
             )

--- a/user/src/test/kotlin/com/damaba/user/application/service/user/UserServiceTest.kt
+++ b/user/src/test/kotlin/com/damaba/user/application/service/user/UserServiceTest.kt
@@ -80,7 +80,7 @@ class UserServiceTest {
         val newGender = Gender.FEMALE
         val newInstagramId = null
         val newProfileImageUrl = UserProfileImage(randomString(), randomUrl())
-        val command = UpdateMyInfoUseCase.Command(userId, newNickname, newGender, newInstagramId, newProfileImageUrl)
+        val command = UpdateMyInfoUseCase.Command(userId, newNickname, newInstagramId, newProfileImageUrl)
         val expectedResult = createUser(
             nickname = newNickname,
             gender = newGender,
@@ -117,7 +117,7 @@ class UserServiceTest {
         val userId = randomLong()
         val user = createUser(id = userId)
         val newNickname = randomString(len = 7)
-        val command = UpdateMyInfoUseCase.Command(userId, newNickname, user.gender, user.instagramId, user.profileImage)
+        val command = UpdateMyInfoUseCase.Command(userId, newNickname, user.instagramId, user.profileImage)
         val expectedResult = createUser(
             nickname = newNickname,
             gender = user.gender,
@@ -152,7 +152,7 @@ class UserServiceTest {
         val user = createUser(id = userId)
         val newProfileImageUrl = UserProfileImage(randomString(), randomUrl())
         val command =
-            UpdateMyInfoUseCase.Command(userId, user.nickname, user.gender, user.instagramId, newProfileImageUrl)
+            UpdateMyInfoUseCase.Command(userId, user.nickname, user.instagramId, newProfileImageUrl)
         val expectedResult = createUser(
             nickname = user.nickname,
             gender = user.gender,
@@ -188,7 +188,6 @@ class UserServiceTest {
         val command = UpdateMyInfoUseCase.Command(
             userId,
             existingNickname,
-            Gender.FEMALE,
             randomString(),
             UserProfileImage(randomString(), randomUrl()),
         )

--- a/user/src/test/kotlin/com/damaba/user/domain/user/UserTest.kt
+++ b/user/src/test/kotlin/com/damaba/user/domain/user/UserTest.kt
@@ -1,6 +1,5 @@
 package com.damaba.user.domain.user
 
-import com.damaba.user.domain.user.constant.Gender
 import com.damaba.user.domain.user.constant.LoginType
 import com.damaba.user.domain.user.constant.UserRoleType
 import com.damaba.user.domain.user.constant.UserType
@@ -40,21 +39,18 @@ class UserTest {
         // given
         val user = createUser()
         val newNickname = randomString()
-        val newGender = Gender.FEMALE
         val newInstagramId = randomString()
         val newProfileImage = UserProfileImage(randomString(), randomUrl())
 
         // when
         user.update(
             nickname = newNickname,
-            gender = newGender,
             instagramId = newInstagramId,
             profileImage = newProfileImage,
         )
 
         // then
         assertThat(user.nickname).isEqualTo(newNickname)
-        assertThat(user.gender).isEqualTo(newGender)
         assertThat(user.instagramId).isEqualTo(newInstagramId)
         assertThat(user.profileImage).isEqualTo(newProfileImage)
     }


### PR DESCRIPTION
Closed #60 

- 내 정보 수정 API에서 성별을 수정 불가능하도록 API 변경