### PR TITLE
프로모션 상세 조회 시의 조회수 증가 로직에 대한 동시성 이슈 개선

### DIFF
--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/common/TransactionalDBLockManager.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/common/TransactionalDBLockManager.kt
@@ -1,0 +1,28 @@
+package com.damaba.damaba.adapter.outbound.common
+
+import com.damaba.damaba.adapter.outbound.promotion.PromotionJpaRepository
+import com.damaba.damaba.domain.common.LockType
+import com.damaba.damaba.domain.promotion.Promotion
+import org.aspectj.lang.ProceedingJoinPoint
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
+
+@Component
+class TransactionalDBLockManager(private val promotionJpaRepository: PromotionJpaRepository) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun executeWithLock(joinPoint: ProceedingJoinPoint, lockType: LockType, domainType: KClass<*>, id: Any): Any {
+        when (lockType) {
+            LockType.PESSIMISTIC -> {
+                when (domainType) {
+                    Promotion::class -> promotionJpaRepository.acquireLockById(id as Long)
+                }
+            }
+
+            LockType.OPTIMISTIC -> throw UnsupportedOperationException("Optimistic locking is not currently supported.")
+        }
+
+        return joinPoint.proceed()
+    }
+}

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJpaRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJpaRepository.kt
@@ -1,15 +1,21 @@
 package com.damaba.damaba.adapter.outbound.promotion
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import java.util.Optional
 
 interface PromotionJpaRepository : JpaRepository<PromotionJpaEntity, Long> {
-    @Query("SELECT promotion From PromotionJpaEntity promotion WHERE promotion.deletedAt IS NULL AND promotion.id = :id")
+    @Query("SELECT p From PromotionJpaEntity p WHERE p.deletedAt IS NULL AND p.id = :id")
     override fun findById(id: Long): Optional<PromotionJpaEntity>
 
-    @Query("SELECT promotion FROM PromotionJpaEntity promotion WHERE promotion.deletedAt IS NULL")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT 1 FROM PromotionJpaEntity p WHERE p.deletedAt IS NULL AND p.id = :id")
+    fun acquireLockById(id: Long)
+
+    @Query("SELECT p FROM PromotionJpaEntity p WHERE p.deletedAt IS NULL")
     override fun findAll(pageable: Pageable): Page<PromotionJpaEntity>
 }

--- a/src/main/kotlin/com/damaba/damaba/application/service/promotion/PromotionService.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/service/promotion/PromotionService.kt
@@ -9,7 +9,9 @@ import com.damaba.damaba.application.port.outbound.promotion.FindPromotionsPort
 import com.damaba.damaba.application.port.outbound.promotion.GetPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.UpdatePromotionPort
 import com.damaba.damaba.application.port.outbound.user.GetUserPort
+import com.damaba.damaba.domain.common.LockType
 import com.damaba.damaba.domain.common.Pagination
+import com.damaba.damaba.domain.common.TransactionalLock
 import com.damaba.damaba.domain.file.Image
 import com.damaba.damaba.domain.promotion.Promotion
 import com.damaba.damaba.domain.promotion.PromotionDetail
@@ -33,8 +35,8 @@ class PromotionService(
     @Transactional(readOnly = true)
     override fun getPromotion(promotionId: Long): Promotion = getPromotionPort.getById(promotionId)
 
-    // TODO: 동시성 이슈 개선
     // TODO: `saveCount`, `isSaved`는 추후 저장 기능 구현 후 반영 로직 추가
+    @TransactionalLock(lockType = LockType.PESSIMISTIC, domainType = Promotion::class, idFieldName = "promotionId")
     override fun getPromotionDetail(promotionId: Long): PromotionDetail {
         val promotion = getPromotionPort.getById(promotionId)
 

--- a/src/main/kotlin/com/damaba/damaba/config/TransactionalLockAspect.kt
+++ b/src/main/kotlin/com/damaba/damaba/config/TransactionalLockAspect.kt
@@ -1,0 +1,28 @@
+package com.damaba.damaba.config
+
+import com.damaba.damaba.adapter.outbound.common.TransactionalDBLockManager
+import com.damaba.damaba.domain.common.TransactionalLock
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class TransactionalLockAspect(private val transactionalLockManager: TransactionalDBLockManager) {
+    @Around("@annotation(transactionalLock)")
+    fun applyTransactionalLock(joinPoint: ProceedingJoinPoint, transactionalLock: TransactionalLock): Any {
+        val methodSignature = joinPoint.signature as MethodSignature
+        val idFieldIdx = methodSignature.parameterNames.indexOf(transactionalLock.idFieldName)
+        if (idFieldIdx == -1) {
+            throw IllegalArgumentException("Parameter '${transactionalLock.idFieldName}' does not exist in method '${methodSignature.name}'")
+        }
+        return transactionalLockManager.executeWithLock(
+            joinPoint = joinPoint,
+            lockType = transactionalLock.lockType,
+            domainType = transactionalLock.domainType,
+            id = joinPoint.args[idFieldIdx],
+        )
+    }
+}

--- a/src/main/kotlin/com/damaba/damaba/domain/common/LockType.kt
+++ b/src/main/kotlin/com/damaba/damaba/domain/common/LockType.kt
@@ -1,0 +1,6 @@
+package com.damaba.damaba.domain.common
+
+enum class LockType {
+    PESSIMISTIC,
+    OPTIMISTIC,
+}

--- a/src/main/kotlin/com/damaba/damaba/domain/common/TransactionalLock.kt
+++ b/src/main/kotlin/com/damaba/damaba/domain/common/TransactionalLock.kt
@@ -1,0 +1,11 @@
+package com.damaba.damaba.domain.common
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TransactionalLock(
+    val lockType: LockType,
+    val domainType: KClass<*>,
+    val idFieldName: String,
+)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -17,9 +17,7 @@ spring:
 
   sql:
     init:
-      mode: embedded
-      schema-locations: classpath:schema.sql
-      data-locations:
+      mode: never
 
   jpa:
     hibernate:

--- a/src/test/kotlin/com/damaba/damaba/application/service/promotion/PromotionServiceTest.kt
+++ b/src/test/kotlin/com/damaba/damaba/application/service/promotion/PromotionServiceTest.kt
@@ -1,5 +1,7 @@
 package com.damaba.damaba.application.service.promotion
 
+import com.damaba.damaba.adapter.outbound.promotion.PromotionCoreRepository
+import com.damaba.damaba.adapter.outbound.user.UserCoreRepository
 import com.damaba.damaba.application.port.inbound.promotion.FindPromotionsUseCase
 import com.damaba.damaba.application.port.inbound.promotion.PostPromotionUseCase
 import com.damaba.damaba.application.port.outbound.promotion.CreatePromotionPort
@@ -28,150 +30,187 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIterable
+import org.junit.jupiter.api.Nested
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.concurrent.CompletableFuture
 import kotlin.test.Test
 
 class PromotionServiceTest {
-    private val getPromotionPort: GetPromotionPort = mockk()
-    private val getUserPort: GetUserPort = mockk()
-    private val findPromotionsPort: FindPromotionsPort = mockk()
-    private val createPromotionPort: CreatePromotionPort = mockk()
-    private val updatePromotionPort: UpdatePromotionPort = mockk()
 
-    private val sut: PromotionService = PromotionService(
-        getPromotionPort,
-        getUserPort,
-        findPromotionsPort,
-        createPromotionPort,
-        updatePromotionPort,
-    )
+    @Nested
+    inner class UnitTest {
+        private val getPromotionPort: GetPromotionPort = mockk()
+        private val getUserPort: GetUserPort = mockk()
+        private val findPromotionsPort: FindPromotionsPort = mockk()
+        private val createPromotionPort: CreatePromotionPort = mockk()
+        private val updatePromotionPort: UpdatePromotionPort = mockk()
 
-    private fun confirmVerifiedEveryMocks() {
-        confirmVerified(
+        private val sut: PromotionService = PromotionService(
             getPromotionPort,
             getUserPort,
             findPromotionsPort,
             createPromotionPort,
             updatePromotionPort,
         )
-    }
 
-    @Test
-    fun `프로모션 id가 주어지고, 일치하는 프로모션을 단건 조회한다`() {
-        // given
-        val promotionId = randomLong()
-        val expectedResult = createPromotion()
-        every { getPromotionPort.getById(promotionId) } returns expectedResult
+        private fun confirmVerifiedEveryMocks() {
+            confirmVerified(
+                getPromotionPort,
+                getUserPort,
+                findPromotionsPort,
+                createPromotionPort,
+                updatePromotionPort,
+            )
+        }
 
-        // when
-        val actualResult = sut.getPromotion(promotionId)
+        @Test
+        fun `프로모션 id가 주어지고, 일치하는 프로모션을 단건 조회한다`() {
+            // given
+            val promotionId = randomLong()
+            val expectedResult = createPromotion()
+            every { getPromotionPort.getById(promotionId) } returns expectedResult
 
-        // then
-        verify { getPromotionPort.getById(promotionId) }
-        confirmVerifiedEveryMocks()
-        assertThat(actualResult).isEqualTo(expectedResult)
-    }
+            // when
+            val actualResult = sut.getPromotion(promotionId)
 
-    @Test
-    fun `id가 주어지고, 주어진 id에 해당하는 프로모션의 상세 정보를 조회하면, 조회수가 1 증가하고 프로모션 상세 정보가 반환된다`() {
-        // given
-        val promotionId = randomLong()
-        val originalViewCount = randomLong()
-        val promotion = createPromotion(id = promotionId, viewCount = originalViewCount)
-        val author = createUser(id = promotion.authorId!!)
-        every { getPromotionPort.getById(promotionId) } returns promotion
-        every { updatePromotionPort.update(any(Promotion::class)) } returns promotion
-        every { getUserPort.getById(promotion.authorId!!) } returns author
+            // then
+            verify { getPromotionPort.getById(promotionId) }
+            confirmVerifiedEveryMocks()
+            assertThat(actualResult).isEqualTo(expectedResult)
+        }
 
-        // when
-        val result = sut.getPromotionDetail(promotionId)
+        @Test
+        fun `id가 주어지고, 프로모션을 상세 조회하면, 조회수가 1 증가하고 프로모션 상세 정보가 반환된다`() {
+            // given
+            val promotionId = randomLong()
+            val originalViewCount = randomLong()
+            val promotion = createPromotion(id = promotionId, viewCount = originalViewCount)
+            val author = createUser(id = promotion.authorId!!)
+            every { getPromotionPort.getById(promotionId) } returns promotion
+            every { updatePromotionPort.update(any(Promotion::class)) } returns promotion
+            every { getUserPort.getById(promotion.authorId!!) } returns author
 
-        // then
-        verify { getPromotionPort.getById(promotionId) }
-        verify { updatePromotionPort.update(any(Promotion::class)) }
-        verify { getUserPort.getById(promotion.authorId!!) }
-        confirmVerifiedEveryMocks()
-        assertThat(result.id).isEqualTo(promotion.id)
-        assertThat(result.viewCount).isEqualTo(originalViewCount + 1)
-    }
+            // when
+            val result = sut.getPromotionDetail(promotionId)
 
-    @Test
-    fun `id가 주어지고, 일치하는 프로모션의 상세 정보를 조회하면, 조회수가 1 증가하고 프로모션 상세 정보가 반환된다, 작성자 정보가 존재하지 않는다면 null로 설정된다`() {
-        // given
-        val promotionId = randomLong()
-        val originalViewCount = randomLong()
-        val promotion = createPromotion(id = promotionId, authorId = null, viewCount = originalViewCount)
-        every { getPromotionPort.getById(promotionId) } returns promotion
-        every { updatePromotionPort.update(any(Promotion::class)) } returns promotion
+            // then
+            verify { getPromotionPort.getById(promotionId) }
+            verify { updatePromotionPort.update(any(Promotion::class)) }
+            verify { getUserPort.getById(promotion.authorId!!) }
+            confirmVerifiedEveryMocks()
+            assertThat(result.id).isEqualTo(promotion.id)
+            assertThat(result.viewCount).isEqualTo(originalViewCount + 1)
+        }
 
-        // when
-        val result = sut.getPromotionDetail(promotionId)
+        @Test
+        fun `id가 주어지고, 프로모션을 상세 조회하면, 조회수가 1 증가하고 프로모션 상세 정보가 반환된다, 작성자가 존재하지 않는다면 null로 설정된다`() {
+            // given
+            val promotionId = randomLong()
+            val originalViewCount = randomLong()
+            val promotion = createPromotion(id = promotionId, authorId = null, viewCount = originalViewCount)
+            every { getPromotionPort.getById(promotionId) } returns promotion
+            every { updatePromotionPort.update(any(Promotion::class)) } returns promotion
 
-        // then
-        verify { getPromotionPort.getById(promotionId) }
-        verify { updatePromotionPort.update(any(Promotion::class)) }
-        confirmVerifiedEveryMocks()
-        assertThat(result.id).isEqualTo(promotion.id)
-        assertThat(result.author).isNull()
-        assertThat(result.viewCount).isEqualTo(originalViewCount + 1)
-    }
+            // when
+            val result = sut.getPromotionDetail(promotionId)
 
-    @Test
-    fun `프로모션 리스트를 조회한다`() {
-        // given
-        val query = FindPromotionsUseCase.Query(
-            page = 1,
-            pageSize = randomInt(min = 5, max = 10),
+            // then
+            verify { getPromotionPort.getById(promotionId) }
+            verify { updatePromotionPort.update(any(Promotion::class)) }
+            confirmVerifiedEveryMocks()
+            assertThat(result.id).isEqualTo(promotion.id)
+            assertThat(result.author).isNull()
+            assertThat(result.viewCount).isEqualTo(originalViewCount + 1)
+        }
+
+        @Test
+        fun `프로모션 리스트를 조회한다`() {
+            // given
+            val query = FindPromotionsUseCase.Query(
+                page = 1,
+                pageSize = randomInt(min = 5, max = 10),
+            )
+            val expectedResult = Pagination(
+                items = generateRandomList(maxSize = query.pageSize) { createPromotion() },
+                page = query.page,
+                pageSize = query.pageSize,
+                totalPage = 1,
+            )
+            every {
+                findPromotionsPort.findPromotions(page = query.page, pageSize = query.pageSize)
+            } returns expectedResult
+
+            // when
+            val actualResult = sut.findPromotions(query)
+
+            // then
+            verify { findPromotionsPort.findPromotions(page = query.page, pageSize = query.pageSize) }
+            confirmVerifiedEveryMocks()
+            assertThat(actualResult).isEqualTo(expectedResult)
+        }
+
+        @Test
+        fun `등록할 이벤트 프로모션 정보들이 주어지고, 주어진 정보로 이벤트 프로모션을 생성 및 등록한다`() {
+            // given
+            val command = createPostPromotionCommand()
+            val expectedResult = createPromotion()
+            every { createPromotionPort.create(any(Promotion::class)) } returns expectedResult
+
+            // when
+            val actualResult = sut.postPromotion(command)
+
+            // then
+            verify { createPromotionPort.create(any(Promotion::class)) }
+            confirmVerifiedEveryMocks()
+            assertThat(actualResult).isEqualTo(expectedResult)
+            assertThatIterable(actualResult.images).isEqualTo(expectedResult.images)
+            assertThatIterable(actualResult.activeRegions).isEqualTo(expectedResult.activeRegions)
+            assertThatIterable(actualResult.hashtags).isEqualTo(expectedResult.hashtags)
+        }
+
+        private fun createPostPromotionCommand() = PostPromotionUseCase.Command(
+            authorId = randomLong(),
+            promotionType = PromotionType.FREE,
+            title = randomString(len = 10),
+            content = randomString(),
+            address = createAddress(),
+            externalLink = randomString(),
+            startedAt = randomLocalDate(),
+            endedAt = randomLocalDate(),
+            photographyTypes = setOf(PhotographyType.SNAP),
+            images = generateRandomList(maxSize = 10) { createImage() },
+            activeRegions = generateRandomSet(maxSize = 5) { createRegion() },
+            hashtags = generateRandomSet(maxSize = 5) { randomString() },
         )
-        val expectedResult = Pagination(
-            items = generateRandomList(maxSize = query.pageSize) { createPromotion() },
-            page = query.page,
-            pageSize = query.pageSize,
-            totalPage = 1,
-        )
-        every {
-            findPromotionsPort.findPromotions(page = query.page, pageSize = query.pageSize)
-        } returns expectedResult
-
-        // when
-        val actualResult = sut.findPromotions(query)
-
-        // then
-        verify { findPromotionsPort.findPromotions(page = query.page, pageSize = query.pageSize) }
-        confirmVerifiedEveryMocks()
-        assertThat(actualResult).isEqualTo(expectedResult)
     }
 
-    @Test
-    fun `등록할 이벤트 프로모션 정보들이 주어지고, 주어진 정보로 이벤트 프로모션을 생성 및 등록한다`() {
-        // given
-        val command = createPostPromotionCommand()
-        val expectedResult = createPromotion()
-        every { createPromotionPort.create(any(Promotion::class)) } returns expectedResult
+    @Nested
+    @ActiveProfiles("test")
+    @SpringBootTest
+    inner class ConcurrencyTest @Autowired constructor(
+        private val promotionService: PromotionService,
+        private val userRepository: UserCoreRepository,
+        private val promotionRepository: PromotionCoreRepository,
+    ) {
+        @Test
+        fun `동시에 여러 번 프로모션 상세 조회할 때, 조회수가 정확히 반영된다`() {
+            // given
+            val author = userRepository.create(createUser())
+            val promotion = promotionRepository.create(createPromotion(authorId = author.id, viewCount = 0))
+            val repeatTime = 10
 
-        // when
-        val actualResult = sut.postPromotion(command)
+            // when
+            val futures = mutableListOf<CompletableFuture<Void>>()
+            repeat(repeatTime) {
+                futures.add(CompletableFuture.runAsync { promotionService.getPromotionDetail(promotion.id) })
+            }
+            CompletableFuture.allOf(*futures.toTypedArray()).join()
 
-        // then
-        verify { createPromotionPort.create(any(Promotion::class)) }
-        confirmVerifiedEveryMocks()
-        assertThat(actualResult).isEqualTo(expectedResult)
-        assertThatIterable(actualResult.images).isEqualTo(expectedResult.images)
-        assertThatIterable(actualResult.activeRegions).isEqualTo(expectedResult.activeRegions)
-        assertThatIterable(actualResult.hashtags).isEqualTo(expectedResult.hashtags)
+            // then
+            val viewCount = promotionService.getPromotion(promotion.id).viewCount
+            assertThat(viewCount).isEqualTo(repeatTime.toLong())
+        }
     }
-
-    private fun createPostPromotionCommand() = PostPromotionUseCase.Command(
-        authorId = randomLong(),
-        promotionType = PromotionType.FREE,
-        title = randomString(len = 10),
-        content = randomString(),
-        address = createAddress(),
-        externalLink = randomString(),
-        startedAt = randomLocalDate(),
-        endedAt = randomLocalDate(),
-        photographyTypes = setOf(PhotographyType.SNAP),
-        images = generateRandomList(maxSize = 10) { createImage() },
-        activeRegions = generateRandomSet(maxSize = 5) { createRegion() },
-        hashtags = generateRandomSet(maxSize = 5) { randomString() },
-    )
 }


### PR DESCRIPTION
Closed #93 

- 프로모션 상세 조회 시의 조회수 증가 로직에 대한 동시성 이슈 개선
  - '프로모션 상세 조회' 기능의 경우, 신규 컨텐츠에 대한 동시다발적인 조회가 자주 발생할 것으로 예상됨. 그 때문에 수정 실패 시 복구 로직/방안을 고려해야 하는 optimistic lock 방식보다 pessimistic lock 방식이 적합하다고 판단하였음. 물론 record lock을 취득해야 조회를 할 수 있다는 점에서 비효율적이고 병목이 발생할만한 요소가 될 수 있으나, 이는 추후 트래픽이 많이 나올 경우 redis를 사용하는 등의 방식으로 개선할 예정임.