### PR TITLE
[프로모션 상세 조회 API] 프로모션의 '저장 수', '저장 여부' 조회 로직 추가

### DIFF
--- a/src/main/kotlin/com/damaba/damaba/adapter/inbound/promotion/PromotionController.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/inbound/promotion/PromotionController.kt
@@ -71,8 +71,16 @@ class PromotionController(
         ApiResponse(responseCode = "404", description = "`promotionId`에 일치하는 프로모션이 없는 경우", content = [Content()]),
     )
     @GetMapping("/api/v1/promotions/{promotionId}/details")
-    fun getPromotionDetailV1(@PathVariable promotionId: Long): PromotionDetailResponse {
-        val promotionDetail = getPromotionDetailUseCase.getPromotionDetail(promotionId)
+    fun getPromotionDetailV1(
+        @AuthenticationPrincipal requestUser: User?,
+        @PathVariable promotionId: Long,
+    ): PromotionDetailResponse {
+        val promotionDetail = getPromotionDetailUseCase.getPromotionDetail(
+            GetPromotionDetailUseCase.Query(
+                requestUserId = requestUser?.id,
+                promotionId = promotionId,
+            ),
+        )
         return PromotionMapper.INSTANCE.toPromotionDetailResponse(promotionDetail)
     }
 

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJdslRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJdslRepository.kt
@@ -22,8 +22,7 @@ class PromotionJdslRepository(private val promotionJpaRepository: PromotionJpaRe
         sortType: PromotionSortType,
         pageable: Pageable,
     ): Page<PromotionJpaEntity> {
-        val result = promotionJpaRepository.findPage(pageable) {
-            // Contions 생성
+        return promotionJpaRepository.findPage(pageable) {
             val conditions = mutableListOf<Predicate>()
 
             // 삭제된 프로모션 제외
@@ -81,8 +80,6 @@ class PromotionJdslRepository(private val promotionJpaRepository: PromotionJpaRe
                         PromotionSortType.POPULAR -> path(PromotionJpaEntity::viewCount).desc()
                     },
                 )
-        }
-        val resultNonNull = result.filterNotNull()
-        return resultNonNull
+        }.filterNotNull()
     }
 }

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/SavedPromotionCoreRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/SavedPromotionCoreRepository.kt
@@ -1,6 +1,7 @@
 package com.damaba.damaba.adapter.outbound.promotion
 
 import com.damaba.damaba.application.port.outbound.promotion.CheckSavedPromotionExistencePort
+import com.damaba.damaba.application.port.outbound.promotion.CountSavedPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.CreateSavedPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.DeleteSavedPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.GetSavedPromotionPort
@@ -14,6 +15,7 @@ class SavedPromotionCoreRepository(
     private val savedPromotionJpaRepository: SavedPromotionJpaRepository,
 ) : GetSavedPromotionPort,
     CheckSavedPromotionExistencePort,
+    CountSavedPromotionPort,
     CreateSavedPromotionPort,
     DeleteSavedPromotionPort {
     override fun getByUserIdAndPromotionId(userId: Long, promotionId: Long): SavedPromotion {
@@ -22,10 +24,12 @@ class SavedPromotionCoreRepository(
         return PromotionMapper.INSTANCE.toSavedPromotion(savedPromotion)
     }
 
-    override fun existsByUserIdAndPostId(
+    override fun existsByUserIdAndPromotionId(
         userId: Long,
         promotionId: Long,
     ): Boolean = savedPromotionJpaRepository.existsByUserIdAndPromotionId(userId, promotionId)
+
+    override fun countByPromotionId(promotionId: Long): Long = savedPromotionJpaRepository.countByPromotionId(promotionId)
 
     override fun create(savedPromotion: SavedPromotion) {
         savedPromotionJpaRepository.save(

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/SavedPromotionJpaRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/SavedPromotionJpaRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface SavedPromotionJpaRepository : JpaRepository<SavedPromotionJpaEntity, Long> {
     fun findByUserIdAndPromotionId(userId: Long, promotionId: Long): SavedPromotionJpaEntity?
     fun existsByUserIdAndPromotionId(userId: Long, promotionId: Long): Boolean
+    fun countByPromotionId(promotionId: Long): Long
 }

--- a/src/main/kotlin/com/damaba/damaba/application/port/inbound/promotion/GetPromotionDetailUseCase.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/port/inbound/promotion/GetPromotionDetailUseCase.kt
@@ -7,8 +7,12 @@ interface GetPromotionDetailUseCase {
      * 프로모션 상세 정보(`PromotionDetail`)을 조회한다.
      * 상세 조회 시, 조회수가 1 증가한다.
      *
-     * @param promotionId 조회할 프로모션 id
      * @return 프로모션 상세 정보
      */
-    fun getPromotionDetail(promotionId: Long): PromotionDetail
+    fun getPromotionDetail(query: Query): PromotionDetail
+
+    data class Query(
+        val requestUserId: Long?,
+        val promotionId: Long,
+    )
 }

--- a/src/main/kotlin/com/damaba/damaba/application/port/outbound/promotion/CheckSavedPromotionExistencePort.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/port/outbound/promotion/CheckSavedPromotionExistencePort.kt
@@ -1,5 +1,5 @@
 package com.damaba.damaba.application.port.outbound.promotion
 
 interface CheckSavedPromotionExistencePort {
-    fun existsByUserIdAndPostId(userId: Long, promotionId: Long): Boolean
+    fun existsByUserIdAndPromotionId(userId: Long, promotionId: Long): Boolean
 }

--- a/src/main/kotlin/com/damaba/damaba/application/port/outbound/promotion/CountSavedPromotionPort.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/port/outbound/promotion/CountSavedPromotionPort.kt
@@ -1,0 +1,5 @@
+package com.damaba.damaba.application.port.outbound.promotion
+
+interface CountSavedPromotionPort {
+    fun countByPromotionId(promotionId: Long): Long
+}

--- a/src/main/kotlin/com/damaba/damaba/domain/promotion/PromotionDetail.kt
+++ b/src/main/kotlin/com/damaba/damaba/domain/promotion/PromotionDetail.kt
@@ -19,7 +19,7 @@ data class PromotionDetail(
     val startedAt: LocalDate?,
     val endedAt: LocalDate?,
     val viewCount: Long,
-    val saveCount: Int,
+    val saveCount: Long,
     val isSaved: Boolean,
     val photographyTypes: Set<PhotographyType>,
     val images: List<Image>,

--- a/src/main/kotlin/com/damaba/damaba/mapper/PromotionMapper.kt
+++ b/src/main/kotlin/com/damaba/damaba/mapper/PromotionMapper.kt
@@ -34,7 +34,7 @@ abstract class PromotionMapper {
     abstract fun toPromotionDetail(
         promotion: Promotion,
         author: User?,
-        saveCount: Int,
+        saveCount: Long,
         isSaved: Boolean,
     ): PromotionDetail
 

--- a/src/test/kotlin/com/damaba/damaba/adapter/inbound/promotion/PromotionControllerTest.kt
+++ b/src/test/kotlin/com/damaba/damaba/adapter/inbound/promotion/PromotionControllerTest.kt
@@ -104,14 +104,16 @@ class PromotionControllerTest @Autowired constructor(
         // given
         val promotionId = randomLong(positive = true)
         val expectedResult = createPromotionDetail(id = promotionId, author = null)
-        every { getPromotionDetailUseCase.getPromotionDetail(promotionId) } returns expectedResult
+        every {
+            getPromotionDetailUseCase.getPromotionDetail(GetPromotionDetailUseCase.Query(null, promotionId))
+        } returns expectedResult
 
         // when & then
         mvc.perform(
             get("/api/v1/promotions/$promotionId/details"),
         ).andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(expectedResult.id))
-        verify { getPromotionDetailUseCase.getPromotionDetail(promotionId) }
+        verify { getPromotionDetailUseCase.getPromotionDetail(GetPromotionDetailUseCase.Query(null, promotionId)) }
     }
 
     @Test

--- a/src/test/kotlin/com/damaba/damaba/adapter/outbound/promotion/SavedPromotionCoreRepositoryTest.kt
+++ b/src/test/kotlin/com/damaba/damaba/adapter/outbound/promotion/SavedPromotionCoreRepositoryTest.kt
@@ -52,7 +52,7 @@ class SavedPromotionCoreRepositoryTest @Autowired constructor(
         sut.create(SavedPromotion.create(userId, promotionId))
 
         // when
-        val result = sut.existsByUserIdAndPostId(userId, promotionId)
+        val result = sut.existsByUserIdAndPromotionId(userId, promotionId)
 
         // then
         assertThat(result).isTrue()
@@ -61,7 +61,7 @@ class SavedPromotionCoreRepositoryTest @Autowired constructor(
     @Test
     fun `프로모션 저장 이력 존재 여부를 조회한다, 만약 존재하지 않는다면 false가 반환된다`() {
         // when
-        val result = sut.existsByUserIdAndPostId(randomLong(), randomLong())
+        val result = sut.existsByUserIdAndPromotionId(randomLong(), randomLong())
 
         // then
         assertThat(result).isFalse()

--- a/src/test/kotlin/com/damaba/damaba/util/fixture/PromotionFixture.kt
+++ b/src/test/kotlin/com/damaba/damaba/util/fixture/PromotionFixture.kt
@@ -12,7 +12,6 @@ import com.damaba.damaba.domain.user.User
 import com.damaba.damaba.util.RandomTestUtils.Companion.generateRandomList
 import com.damaba.damaba.util.RandomTestUtils.Companion.generateRandomSet
 import com.damaba.damaba.util.RandomTestUtils.Companion.randomBoolean
-import com.damaba.damaba.util.RandomTestUtils.Companion.randomInt
 import com.damaba.damaba.util.RandomTestUtils.Companion.randomLocalDate
 import com.damaba.damaba.util.RandomTestUtils.Companion.randomLong
 import com.damaba.damaba.util.RandomTestUtils.Companion.randomString
@@ -66,7 +65,7 @@ object PromotionFixture {
         startedAt: LocalDate? = randomLocalDate(),
         endedAt: LocalDate? = randomLocalDate(),
         viewCount: Long = randomLong(),
-        saveCount: Int = randomInt(),
+        saveCount: Long = randomLong(),
         isSaved: Boolean = randomBoolean(),
         photographyTypes: Set<PhotographyType> = setOf(PhotographyType.SNAP),
         images: List<Image> = generateRandomList(maxSize = 10) { createImage() },


### PR DESCRIPTION
Closed #102

- 인증/인가가 필수가 아닌 API에 대해 액세스 토큰을 검증할 수 있도록 AuthFilter로직 수정
- 프로모션 상세 조회 API '저장 수', '내 저장 여부' 조회 로직 추가