### PR TITLE
[프로모션 리스트 조회 API] 응답 데이터에 각 프로모션의 '저장 수', '저장 여부' 추가

### DIFF
--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/common/PageMappingExtensions.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/common/PageMappingExtensions.kt
@@ -4,6 +4,13 @@ import com.damaba.damaba.domain.common.Pagination
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 
+fun <T> Page<T>.toPagination(): Pagination<T> = Pagination(
+    items = this.content,
+    page = this.number,
+    pageSize = this.size,
+    totalPage = this.totalPages,
+)
+
 fun <T, R> Page<T>.toPagination(mapper: (T) -> R): Pagination<R> = Pagination(
     items = this.content.map(mapper),
     page = this.number,

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionCoreRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionCoreRepository.kt
@@ -2,12 +2,13 @@ package com.damaba.damaba.adapter.outbound.promotion
 
 import com.damaba.damaba.adapter.outbound.common.toPagination
 import com.damaba.damaba.application.port.outbound.promotion.CreatePromotionPort
-import com.damaba.damaba.application.port.outbound.promotion.FindPromotionsPort
+import com.damaba.damaba.application.port.outbound.promotion.FindPromotionListPort
 import com.damaba.damaba.application.port.outbound.promotion.GetPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.UpdatePromotionPort
 import com.damaba.damaba.domain.common.Pagination
 import com.damaba.damaba.domain.common.PhotographyType
 import com.damaba.damaba.domain.promotion.Promotion
+import com.damaba.damaba.domain.promotion.PromotionListItem
 import com.damaba.damaba.domain.promotion.constant.PromotionProgressStatus
 import com.damaba.damaba.domain.promotion.constant.PromotionSortType
 import com.damaba.damaba.domain.promotion.constant.PromotionType
@@ -22,12 +23,13 @@ class PromotionCoreRepository(
     private val promotionJpaRepository: PromotionJpaRepository,
     private val promotionJdslRepository: PromotionJdslRepository,
 ) : GetPromotionPort,
-    FindPromotionsPort,
+    FindPromotionListPort,
     CreatePromotionPort,
     UpdatePromotionPort {
     override fun getById(id: Long): Promotion = PromotionMapper.INSTANCE.toPromotion(getJpaEntityById(id))
 
-    override fun findPromotions(
+    override fun findPromotionList(
+        reqUserId: Long?,
         type: PromotionType?,
         progressStatus: PromotionProgressStatus?,
         regions: Set<RegionFilterCondition>,
@@ -35,9 +37,15 @@ class PromotionCoreRepository(
         sortType: PromotionSortType,
         page: Int,
         pageSize: Int,
-    ): Pagination<Promotion> = promotionJdslRepository
-        .findPromotions(type, progressStatus, regions, photographyTypes, sortType, PageRequest.of(page, pageSize))
-        .toPagination { PromotionMapper.INSTANCE.toPromotion(it) }
+    ): Pagination<PromotionListItem> = promotionJdslRepository.findPromotionList(
+        reqUserId,
+        type,
+        progressStatus,
+        regions,
+        photographyTypes,
+        sortType,
+        PageRequest.of(page, pageSize),
+    ).toPagination()
 
     override fun create(promotion: Promotion): Promotion {
         val promotionJpaEntity = promotionJpaRepository.save(PromotionMapper.INSTANCE.toPromotionJpaEntity(promotion))

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJdslRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJdslRepository.kt
@@ -1,12 +1,17 @@
 package com.damaba.damaba.adapter.outbound.promotion
 
 import com.damaba.damaba.adapter.outbound.common.filterNotNull
+import com.damaba.damaba.adapter.outbound.user.UserJpaEntity
 import com.damaba.damaba.domain.common.PhotographyType
+import com.damaba.damaba.domain.promotion.PromotionListItem
 import com.damaba.damaba.domain.promotion.constant.PromotionProgressStatus
 import com.damaba.damaba.domain.promotion.constant.PromotionSortType
 import com.damaba.damaba.domain.promotion.constant.PromotionType
 import com.damaba.damaba.domain.region.RegionFilterCondition
+import com.damaba.damaba.mapper.PromotionMapper
+import com.damaba.damaba.mapper.UserMapper
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
+import jakarta.persistence.Tuple
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
@@ -14,15 +19,16 @@ import java.time.LocalDate
 
 @Repository
 class PromotionJdslRepository(private val promotionJpaRepository: PromotionJpaRepository) {
-    fun findPromotions(
+    fun findPromotionList(
+        requestUserId: Long?,
         type: PromotionType?,
         progressStatus: PromotionProgressStatus?,
         regions: Set<RegionFilterCondition>,
         photographyTypes: Set<PhotographyType>,
         sortType: PromotionSortType,
         pageable: Pageable,
-    ): Page<PromotionJpaEntity> {
-        return promotionJpaRepository.findPage(pageable) {
+    ): Page<PromotionListItem> {
+        val result = promotionJpaRepository.findPage(pageable) {
             val conditions = mutableListOf<Predicate>()
 
             // 삭제된 프로모션 제외
@@ -66,20 +72,54 @@ class PromotionJdslRepository(private val promotionJpaRepository: PromotionJpaRe
                 conditions += or(*regionConditions.toTypedArray())
             }
 
+            val saveCountQuery = select(count(SavedPromotionJpaEntity::id))
+                .from(entity(SavedPromotionJpaEntity::class))
+                .where(path(SavedPromotionJpaEntity::promotionId).eq(path(PromotionJpaEntity::id)))
+                .asSubquery()
+
+            val isSavedQuery = select(path(SavedPromotionJpaEntity::id))
+                .from(entity(SavedPromotionJpaEntity::class))
+                .whereAnd(
+                    path(SavedPromotionJpaEntity::promotionId).eq(path(PromotionJpaEntity::id)),
+                    path(SavedPromotionJpaEntity::userId).eq(requestUserId),
+                ).asSubquery()
+
             // Query 생성
-            selectDistinct(entity(PromotionJpaEntity::class))
-                .from(
-                    entity(PromotionJpaEntity::class),
-                    leftJoin(PromotionJpaEntity::activeRegions).`as`(entity(PromotionActiveRegionJpaEntity::class)),
-                    leftJoin(PromotionJpaEntity::photographyTypes).`as`(entity(PromotionPhotographyTypeJpaEntity::class)),
-                )
-                .whereAnd(*conditions.toTypedArray())
-                .orderBy(
-                    when (sortType) {
-                        PromotionSortType.LATEST -> path(PromotionJpaEntity::createdAt).desc()
-                        PromotionSortType.POPULAR -> path(PromotionJpaEntity::viewCount).desc()
-                    },
-                )
-        }.filterNotNull()
+            val saveCount = expression(Long::class, "saveCount")
+            val isSaved = expression(Boolean::class, "isSaved")
+            selectDistinct<Tuple>(
+                entity(PromotionJpaEntity::class),
+                entity(UserJpaEntity::class),
+                saveCountQuery.`as`(saveCount),
+                exists(isSavedQuery).`as`(isSaved),
+            ).from(
+                entity(PromotionJpaEntity::class),
+                leftFetchJoin(UserJpaEntity::class)
+                    .on(path(PromotionJpaEntity::authorId).eq(path(UserJpaEntity::id))),
+                leftJoin(PromotionPhotographyTypeJpaEntity::class).on(
+                    path(PromotionPhotographyTypeJpaEntity::promotion)(PromotionJpaEntity::id)
+                        .eq(path(PromotionJpaEntity::id)),
+                ),
+                leftJoin(PromotionActiveRegionJpaEntity::class).on(
+                    path(PromotionActiveRegionJpaEntity::promotion)(PromotionJpaEntity::id)
+                        .eq(path(PromotionJpaEntity::id)),
+                ),
+            ).whereAnd(
+                *conditions.toTypedArray(),
+            ).orderBy(
+                when (sortType) {
+                    PromotionSortType.LATEST -> path(PromotionJpaEntity::createdAt).desc()
+                    PromotionSortType.POPULAR -> path(PromotionJpaEntity::viewCount).desc()
+                },
+            )
+        }
+        return result.filterNotNull().map { tuple ->
+            PromotionMapper.INSTANCE.toPromotionListItem(
+                promotion = PromotionMapper.INSTANCE.toPromotion(tuple.get(0) as PromotionJpaEntity),
+                author = tuple.get(1)?.let { UserMapper.INSTANCE.toUser(it as UserJpaEntity) },
+                saveCount = tuple.get(2) as Long,
+                isSaved = tuple.get(3) as Boolean,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJdslRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionJdslRepository.kt
@@ -109,7 +109,7 @@ class PromotionJdslRepository(private val promotionJpaRepository: PromotionJpaRe
             ).orderBy(
                 when (sortType) {
                     PromotionSortType.LATEST -> path(PromotionJpaEntity::createdAt).desc()
-                    PromotionSortType.POPULAR -> path(PromotionJpaEntity::viewCount).desc()
+                    PromotionSortType.POPULAR -> saveCount.desc()
                 },
             )
         }

--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionPhotographyTypeJpaEntity.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/promotion/PromotionPhotographyTypeJpaEntity.kt
@@ -23,7 +23,7 @@ class PromotionPhotographyTypeJpaEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
-    private val id: Long = 0
+    val id: Long = 0
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "promotion_id", nullable = false)

--- a/src/main/kotlin/com/damaba/damaba/application/port/inbound/promotion/FindPromotionListUseCase.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/port/inbound/promotion/FindPromotionListUseCase.kt
@@ -3,16 +3,17 @@ package com.damaba.damaba.application.port.inbound.promotion
 import com.damaba.damaba.domain.common.Pagination
 import com.damaba.damaba.domain.common.PhotographyType
 import com.damaba.damaba.domain.exception.ValidationException
-import com.damaba.damaba.domain.promotion.Promotion
+import com.damaba.damaba.domain.promotion.PromotionListItem
 import com.damaba.damaba.domain.promotion.constant.PromotionProgressStatus
 import com.damaba.damaba.domain.promotion.constant.PromotionSortType
 import com.damaba.damaba.domain.promotion.constant.PromotionType
 import com.damaba.damaba.domain.region.RegionFilterCondition
 
-interface FindPromotionsUseCase {
-    fun findPromotions(query: Query): Pagination<Promotion>
+interface FindPromotionListUseCase {
+    fun findPromotionList(query: Query): Pagination<PromotionListItem>
 
     data class Query(
+        val reqUserId: Long?,
         val type: PromotionType?,
         val progressStatus: PromotionProgressStatus?,
         val regions: Set<RegionFilterCondition>,

--- a/src/main/kotlin/com/damaba/damaba/application/port/outbound/promotion/FindPromotionListPort.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/port/outbound/promotion/FindPromotionListPort.kt
@@ -2,14 +2,15 @@ package com.damaba.damaba.application.port.outbound.promotion
 
 import com.damaba.damaba.domain.common.Pagination
 import com.damaba.damaba.domain.common.PhotographyType
-import com.damaba.damaba.domain.promotion.Promotion
+import com.damaba.damaba.domain.promotion.PromotionListItem
 import com.damaba.damaba.domain.promotion.constant.PromotionProgressStatus
 import com.damaba.damaba.domain.promotion.constant.PromotionSortType
 import com.damaba.damaba.domain.promotion.constant.PromotionType
 import com.damaba.damaba.domain.region.RegionFilterCondition
 
-interface FindPromotionsPort {
-    fun findPromotions(
+interface FindPromotionListPort {
+    fun findPromotionList(
+        reqUserId: Long?,
         type: PromotionType?,
         progressStatus: PromotionProgressStatus?,
         regions: Set<RegionFilterCondition>,
@@ -17,5 +18,5 @@ interface FindPromotionsPort {
         sortType: PromotionSortType,
         page: Int,
         pageSize: Int,
-    ): Pagination<Promotion>
+    ): Pagination<PromotionListItem>
 }

--- a/src/main/kotlin/com/damaba/damaba/application/service/promotion/PromotionService.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/service/promotion/PromotionService.kt
@@ -1,6 +1,6 @@
 package com.damaba.damaba.application.service.promotion
 
-import com.damaba.damaba.application.port.inbound.promotion.FindPromotionsUseCase
+import com.damaba.damaba.application.port.inbound.promotion.FindPromotionListUseCase
 import com.damaba.damaba.application.port.inbound.promotion.GetPromotionDetailUseCase
 import com.damaba.damaba.application.port.inbound.promotion.GetPromotionUseCase
 import com.damaba.damaba.application.port.inbound.promotion.PostPromotionUseCase
@@ -11,7 +11,7 @@ import com.damaba.damaba.application.port.outbound.promotion.CountSavedPromotion
 import com.damaba.damaba.application.port.outbound.promotion.CreatePromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.CreateSavedPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.DeleteSavedPromotionPort
-import com.damaba.damaba.application.port.outbound.promotion.FindPromotionsPort
+import com.damaba.damaba.application.port.outbound.promotion.FindPromotionListPort
 import com.damaba.damaba.application.port.outbound.promotion.GetPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.GetSavedPromotionPort
 import com.damaba.damaba.application.port.outbound.promotion.UpdatePromotionPort
@@ -22,6 +22,7 @@ import com.damaba.damaba.domain.common.TransactionalLock
 import com.damaba.damaba.domain.file.Image
 import com.damaba.damaba.domain.promotion.Promotion
 import com.damaba.damaba.domain.promotion.PromotionDetail
+import com.damaba.damaba.domain.promotion.PromotionListItem
 import com.damaba.damaba.domain.promotion.SavedPromotion
 import com.damaba.damaba.domain.promotion.exception.AlreadySavedPromotionException
 import com.damaba.damaba.domain.region.Region
@@ -34,7 +35,7 @@ class PromotionService(
     private val getUserPort: GetUserPort,
 
     private val getPromotionPort: GetPromotionPort,
-    private val findPromotionsPort: FindPromotionsPort,
+    private val findPromotionListPort: FindPromotionListPort,
     private val createPromotionPort: CreatePromotionPort,
     private val updatePromotionPort: UpdatePromotionPort,
 
@@ -45,7 +46,7 @@ class PromotionService(
     private val deleteSavedPromotionPort: DeleteSavedPromotionPort,
 ) : GetPromotionUseCase,
     GetPromotionDetailUseCase,
-    FindPromotionsUseCase,
+    FindPromotionListUseCase,
     PostPromotionUseCase,
     SavePromotionUseCase,
     UnsavePromotionUseCase {
@@ -71,9 +72,10 @@ class PromotionService(
     }
 
     @Transactional(readOnly = true)
-    override fun findPromotions(
-        query: FindPromotionsUseCase.Query,
-    ): Pagination<Promotion> = findPromotionsPort.findPromotions(
+    override fun findPromotionList(
+        query: FindPromotionListUseCase.Query,
+    ): Pagination<PromotionListItem> = findPromotionListPort.findPromotionList(
+        query.reqUserId,
         query.type,
         query.progressStatus,
         query.regions,

--- a/src/main/kotlin/com/damaba/damaba/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/damaba/damaba/config/SecurityConfig.kt
@@ -46,7 +46,7 @@ class SecurityConfig(private val env: Environment) {
             "/api/v*/photographers/nicknames/existence" to HttpMethod.GET,
             "/api/v*/promotions/{promotionId:\\d+}" to HttpMethod.GET,
             "/api/v*/promotions/{promotionId:\\d+}/details" to HttpMethod.GET,
-            "/api/v*/promotions" to HttpMethod.GET,
+            "/api/v*/promotions/list" to HttpMethod.GET,
         )
     }
 

--- a/src/main/kotlin/com/damaba/damaba/domain/common/Pagination.kt
+++ b/src/main/kotlin/com/damaba/damaba/domain/common/Pagination.kt
@@ -29,11 +29,4 @@ data class Pagination<T>(
 
     val hasNextPage: Boolean
         get() = !isLastPage
-
-    fun <R> map(mapper: (T) -> R): Pagination<R> = Pagination(
-        items = items.map(mapper),
-        page = page,
-        pageSize = pageSize,
-        totalPage = totalPage,
-    )
 }

--- a/src/main/kotlin/com/damaba/damaba/domain/promotion/PromotionListItem.kt
+++ b/src/main/kotlin/com/damaba/damaba/domain/promotion/PromotionListItem.kt
@@ -1,0 +1,22 @@
+package com.damaba.damaba.domain.promotion
+
+import com.damaba.damaba.domain.file.Image
+import com.damaba.damaba.domain.region.Region
+import com.damaba.damaba.domain.user.User
+import java.time.LocalDate
+
+/**
+ * '이벤트로 담아봐(프로모션 리스트)' 페이지에서 각 리스트 아이템을 담을 도메인 객체
+ */
+data class PromotionListItem(
+    val id: Long,
+    val author: User?,
+    val title: String,
+    val startedAt: LocalDate?,
+    val endedAt: LocalDate?,
+    val saveCount: Long,
+    val isSaved: Boolean,
+    val images: List<Image>,
+    val activeRegions: Set<Region>,
+    val hashtags: Set<String>,
+)

--- a/src/main/kotlin/com/damaba/damaba/mapper/PromotionMapper.kt
+++ b/src/main/kotlin/com/damaba/damaba/mapper/PromotionMapper.kt
@@ -12,6 +12,7 @@ import com.damaba.damaba.domain.common.PhotographyType
 import com.damaba.damaba.domain.file.Image
 import com.damaba.damaba.domain.promotion.Promotion
 import com.damaba.damaba.domain.promotion.PromotionDetail
+import com.damaba.damaba.domain.promotion.PromotionListItem
 import com.damaba.damaba.domain.promotion.SavedPromotion
 import com.damaba.damaba.domain.region.Region
 import com.damaba.damaba.domain.user.User
@@ -37,6 +38,14 @@ abstract class PromotionMapper {
         saveCount: Long,
         isSaved: Boolean,
     ): PromotionDetail
+
+    @Mapping(source = "promotion.id", target = "id")
+    abstract fun toPromotionListItem(
+        promotion: Promotion,
+        author: User?,
+        saveCount: Long,
+        isSaved: Boolean,
+    ): PromotionListItem
 
     abstract fun toSavedPromotion(savedPromotionJpaEntity: SavedPromotionJpaEntity): SavedPromotion
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,4 @@ logging:
       hibernate:
         type: trace
         SQL: debug
+        orm.jdbc.bind: trace

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,7 @@ springdoc:
 logging:
   level:
     com.damaba: debug
+    com.linecorp.kotlinjdsl: debug
     org:
       hibernate:
         type: trace

--- a/src/test/kotlin/com/damaba/damaba/application/port/inbound/promotion/FindPromotionListUseCaseCommandTest.kt
+++ b/src/test/kotlin/com/damaba/damaba/application/port/inbound/promotion/FindPromotionListUseCaseCommandTest.kt
@@ -6,14 +6,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
 import kotlin.test.Test
 
-class FindPromotionsUseCaseCommandTest {
+class FindPromotionListUseCaseCommandTest {
     @Test
     fun `page 번호가 음수라면 validation exception이 발생한다`() {
         // given
 
         // when
         val ex = catchThrowable {
-            FindPromotionsUseCase.Query(
+            FindPromotionListUseCase.Query(
+                reqUserId = null,
                 type = null,
                 progressStatus = null,
                 regions = emptySet(),
@@ -35,7 +36,8 @@ class FindPromotionsUseCaseCommandTest {
 
         // when
         val ex = catchThrowable {
-            FindPromotionsUseCase.Query(
+            FindPromotionListUseCase.Query(
+                reqUserId = null,
                 type = null,
                 progressStatus = null,
                 regions = emptySet(),

--- a/src/test/kotlin/com/damaba/damaba/util/fixture/PromotionFixture.kt
+++ b/src/test/kotlin/com/damaba/damaba/util/fixture/PromotionFixture.kt
@@ -5,6 +5,7 @@ import com.damaba.damaba.domain.common.PhotographyType
 import com.damaba.damaba.domain.file.Image
 import com.damaba.damaba.domain.promotion.Promotion
 import com.damaba.damaba.domain.promotion.PromotionDetail
+import com.damaba.damaba.domain.promotion.PromotionListItem
 import com.damaba.damaba.domain.promotion.SavedPromotion
 import com.damaba.damaba.domain.promotion.constant.PromotionType
 import com.damaba.damaba.domain.region.Region
@@ -85,6 +86,30 @@ object PromotionFixture {
         saveCount = saveCount,
         isSaved = isSaved,
         photographyTypes = photographyTypes,
+        images = images,
+        activeRegions = activeRegions,
+        hashtags = hashtags,
+    )
+
+    fun createPromotionListItem(
+        id: Long = randomLong(),
+        author: User? = createUser(),
+        title: String = randomString(10),
+        startedAt: LocalDate? = randomLocalDate(),
+        endedAt: LocalDate? = randomLocalDate(),
+        saveCount: Long = randomLong(),
+        isSaved: Boolean = randomBoolean(),
+        images: List<Image> = generateRandomList(maxSize = 10) { createImage() },
+        activeRegions: Set<Region> = generateRandomSet(maxSize = 5) { createRegion() },
+        hashtags: Set<String> = generateRandomSet(maxSize = 5) { randomString() },
+    ) = PromotionListItem(
+        id = id,
+        author = author,
+        title = title,
+        startedAt = startedAt,
+        endedAt = endedAt,
+        saveCount = saveCount,
+        isSaved = isSaved,
         images = images,
         activeRegions = activeRegions,
         hashtags = hashtags,


### PR DESCRIPTION
Closed #101

- local 환경에서 DB query parameter 로그 출력되도록 설정
- `PromotionPhotographyTypeJpaEntity` `id` field 접근제어자 수정
- local 환경에서 Kotlin JDSL에 의해 생성된 쿼리 확인할 수 있도록 logging level 설정
- 프로모션 리스트 조회 API 구현
- 프로모션 리스트 조회 API의 '인기순' 정렬 기준 변경 (조회 많은 순 => 저장 많은 순)