### PR TITLE
유저 프로필 이미지 삭제 로직 수정

### DIFF
--- a/src/main/kotlin/com/damaba/damaba/adapter/outbound/user/UserCoreRepository.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/outbound/user/UserCoreRepository.kt
@@ -1,6 +1,7 @@
 package com.damaba.damaba.adapter.outbound.user
 
 import com.damaba.damaba.application.port.outbound.user.CreateUserPort
+import com.damaba.damaba.application.port.outbound.user.DeleteUserProfileImagePort
 import com.damaba.damaba.application.port.outbound.user.ExistsNicknamePort
 import com.damaba.damaba.application.port.outbound.user.FindUserPort
 import com.damaba.damaba.application.port.outbound.user.GetUserPort
@@ -17,7 +18,8 @@ class UserCoreRepository(
     GetUserPort,
     ExistsNicknamePort,
     CreateUserPort,
-    UpdateUserPort {
+    UpdateUserPort,
+    DeleteUserProfileImagePort {
     override fun findById(id: Long): User? = findUserJpaEntityById(id)?.toUser()
 
     override fun findByOAuthLoginUid(oAuthLoginUid: String): User? = userJpaRepository.findByOAuthLoginUid(oAuthLoginUid)?.toUser()
@@ -35,8 +37,7 @@ class UserCoreRepository(
         val userJpaEntity = getUserJpaEntityById(user.id)
 
         if (userJpaEntity.profileImage.url != user.profileImage.url) {
-            val originalProfileImage = userProfileImageJpaRepository.findByUrl(userJpaEntity.profileImage.url)
-            originalProfileImage?.delete()
+            this.deleteProfileImageIfExists(userJpaEntity.profileImage.url)
             userProfileImageJpaRepository.save(
                 UserProfileImageJpaEntity(
                     userId = user.id,
@@ -50,7 +51,11 @@ class UserCoreRepository(
         return userJpaEntity.toUser()
     }
 
-    private fun findUserJpaEntityById(id: Long): UserJpaEntity? = userJpaRepository.findById(id).orElseGet { null }
+    override fun deleteProfileImageIfExists(profileImageUrl: String) {
+        userProfileImageJpaRepository.findByUrl(profileImageUrl)?.delete()
+    }
+
+    private fun findUserJpaEntityById(id: Long): UserJpaEntity? = userJpaRepository.findById(id).orElse(null)
 
     private fun getUserJpaEntityById(id: Long): UserJpaEntity = userJpaRepository.findById(id).orElseThrow { UserNotFoundException() }
 }

--- a/src/main/kotlin/com/damaba/damaba/application/port/outbound/user/DeleteUserProfileImagePort.kt
+++ b/src/main/kotlin/com/damaba/damaba/application/port/outbound/user/DeleteUserProfileImagePort.kt
@@ -1,0 +1,11 @@
+package com.damaba.damaba.application.port.outbound.user
+
+interface DeleteUserProfileImagePort {
+    /**
+     * 프로필 이미지를 삭제한다.
+     * `profileImageUrl`에 해당하는 이미지가 존재하지 않는 경우 무시된다.
+     *
+     * @param profileImageUrl 삭제할 프로필 이미지의 url
+     */
+    fun deleteProfileImageIfExists(profileImageUrl: String)
+}

--- a/src/main/kotlin/com/damaba/damaba/domain/file/DeleteFileEvent.kt
+++ b/src/main/kotlin/com/damaba/damaba/domain/file/DeleteFileEvent.kt
@@ -1,5 +1,0 @@
-package com.damaba.damaba.domain.file
-
-data class DeleteFileEvent(val urls: List<String>) {
-    constructor(url: String) : this(listOf(url))
-}

--- a/src/test/kotlin/com/damaba/damaba/adapter/outbound/user/UserCoreRepositoryTest.kt
+++ b/src/test/kotlin/com/damaba/damaba/adapter/outbound/user/UserCoreRepositoryTest.kt
@@ -22,7 +22,6 @@ class UserCoreRepositoryTest @Autowired constructor(
     private val userCoreRepository: UserCoreRepository,
     private val userProfileImageJpaRepository: UserProfileImageJpaRepository,
 ) {
-
     @Test
     fun `특정 유저의 id가 주어지고, 주어진 id에 해당하는 유저를 조회하면, 유저 정보가 반환된다`() {
         // given
@@ -226,5 +225,32 @@ class UserCoreRepositoryTest @Autowired constructor(
 
         val foundOriginalProfileImage = userProfileImageJpaRepository.findByUrl(originalUser.profileImage.url)
         assertThat(foundOriginalProfileImage).isNull()
+    }
+
+    @Test
+    fun `프로필 이미지 url이 주어지고, 프로필 이미지를 삭제한다`() {
+        // given
+        val profileImageUrl = randomUrl()
+        userProfileImageJpaRepository.save(
+            UserProfileImageJpaEntity(userId = randomLong(), url = profileImageUrl, name = randomString()),
+        )
+
+        // when
+        userCoreRepository.deleteProfileImageIfExists(profileImageUrl)
+
+        // then
+        assertThat(userProfileImageJpaRepository.findByUrl(profileImageUrl)).isNull()
+    }
+
+    @Test
+    fun `프로필 이미지 url이 주어지고, 프로필 이미지를 삭제한다, 만약 이미지가 존재하지 않는다면 아무런 일이 발생하지 않는다`() {
+        // given
+        val profileImageUrl = randomUrl()
+
+        // when
+        userCoreRepository.deleteProfileImageIfExists(profileImageUrl)
+
+        // then
+        assertThat(userProfileImageJpaRepository.findByUrl(profileImageUrl)).isNull()
     }
 }


### PR DESCRIPTION
Closed #122

- 단순히 이벤트를 발행하는 기존 유저 프로필 이미지 삭제 로직을 실제 soft delete를 하도록 수정