### PR TITLE
Extends PhotographerResponse with roles

### DIFF
--- a/src/main/kotlin/com/damaba/damaba/adapter/inbound/photographer/PhotographerResponse.kt
+++ b/src/main/kotlin/com/damaba/damaba/adapter/inbound/photographer/PhotographerResponse.kt
@@ -6,6 +6,7 @@ import com.damaba.damaba.adapter.inbound.region.dto.RegionResponse
 import com.damaba.damaba.domain.common.PhotographyType
 import com.damaba.damaba.domain.user.constant.Gender
 import com.damaba.damaba.domain.user.constant.LoginType
+import com.damaba.damaba.domain.user.constant.UserRoleType
 import com.damaba.damaba.domain.user.constant.UserType
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -15,6 +16,9 @@ data class PhotographerResponse(
 
     @Schema(description = "User type")
     val type: UserType,
+
+    @Schema(description = "User roles")
+    val roles: Set<UserRoleType>,
 
     @Schema(description = "사용하는 로그인 종류")
     val loginType: LoginType,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE `user`
     roles              VARCHAR(255) NOT NULL,
     login_type         VARCHAR(255) NOT NULL,
     o_auth_login_uid   VARCHAR(255) NOT NULL UNIQUE,
-    nickname           VARCHAR(7)   NOT NULL UNIQUE,
+    nickname           VARCHAR(15)  NOT NULL UNIQUE,
     profile_image_name VARCHAR(255),
     profile_image_url  VARCHAR(255),
     gender             VARCHAR(255) NOT NULL,


### PR DESCRIPTION
Adds user role information to the PhotographerResponse.

This allows clients to determine the permissions and capabilities of a photographer based on their roles.